### PR TITLE
ci: restrict workflow token to least-privilege read permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ on:
 # There's no point in testing an outdated version of the code. GitHub only allows
 # a limited number of job runners to be active at the same time, so it's better to cancel
 # pointless jobs early so that more useful jobs can run sooner.
+# Restrict default token permissions to least privilege.
+# Individual jobs should request only what they need.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds a top-level `permissions: contents: read` block to `.github/workflows/ci.yml`
- Overrides GitHub's default broad `GITHUB_TOKEN` grants with the minimum required for this workflow (checkout + build/lint/test)
- Follows least-privilege principle; any future job needing write access can declare its own `permissions` block

## Test plan

- [x] Verify CI jobs still pass (format, lint, spelling, dev-server-check, build-check)
- [x] Confirm no job requires write permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)